### PR TITLE
Migrate to using @react-native-clipboard/clipboard from react-native-core Clipboard

### DIFF
--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
-import {Text, ScrollView, TouchableOpacity, SafeAreaView, View, Clipboard} from 'react-native';
+import {Text, ScrollView, TouchableOpacity, SafeAreaView, View} from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 import * as Linking from 'expo-linking';
 
 class ErrorBoundary extends Component {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -449,6 +449,8 @@ PODS:
     - React-perflogger (= 0.71.3)
   - RNCAsyncStorage (1.17.11):
     - React-Core
+  - RNCClipboard (1.11.2):
+    - React-Core
   - RNCMaskedView (0.1.11):
     - React
   - RNCPicker (2.4.8):
@@ -564,6 +566,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -723,6 +726,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNCPicker:
@@ -818,6 +823,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7bf0dafc7b727d93c8cb94eb00a9d3753c446c3e
   ReactCommon: 5768a505f0bc7b798dc2becdd3ee6442224f796c
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
+  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@babel/core": "^7.20.0",
         "@freakycoder/react-native-bounceable": "^0.2.5",
         "@react-native-async-storage/async-storage": "1.17.11",
+        "@react-native-clipboard/clipboard": "^1.11.2",
         "@react-native-community/masked-view": "^0.1.11",
         "@react-native-community/netinfo": "9.3.7",
         "@react-native-picker/picker": "2.4.8",
@@ -3890,6 +3891,15 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || 0.60 - 0.71 || 1000.0.0"
+      }
+    },
+    "node_modules/@react-native-clipboard/clipboard": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz",
+      "integrity": "sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==",
+      "peerDependencies": {
+        "react": ">=16.0",
+        "react-native": ">=0.57.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -19353,6 +19363,12 @@
       "requires": {
         "merge-options": "^3.0.4"
       }
+    },
+    "@react-native-clipboard/clipboard": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz",
+      "integrity": "sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==",
+      "requires": {}
     },
     "@react-native-community/cli": {
       "version": "10.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@babel/core": "^7.20.0",
     "@freakycoder/react-native-bounceable": "^0.2.5",
     "@react-native-async-storage/async-storage": "1.17.11",
+    "@react-native-clipboard/clipboard": "^1.11.2",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-community/netinfo": "9.3.7",
     "@react-native-picker/picker": "2.4.8",


### PR DESCRIPTION
The React Native core Clipboard module has been deprecated so we are migrating to @react-native-clipboard/clipboard.