### PR TITLE
Fix categories not displaying if there are more than 10 results in SelectCategorySearchScreen

### DIFF
--- a/screens/SelectCategorySearchScreen.js
+++ b/screens/SelectCategorySearchScreen.js
@@ -69,7 +69,6 @@ const SelectCategorySearchScreen = ({route, navigation}) => {
     const [loadingResults, setLoadingResults] = useState(false);
     const [errorMessage, setErrorMessage] = useState();
     const {serverUrl, setServerUrl} = useContext(ServerUrlContext);
-    var userLoadMax = 10;
 
     const CategoryItem = ({categoryTitle, categoryDescription, members, categoryTags, image, NSFW, NSFL, datePosted, allowScreenShots}) => (
         <SearchFrame onPress={() => navigation.navigate("ThreadUploadPage", {threadFormat: threadFormat, threadTitle: threadTitle, threadSubtitle: threadSubtitle, threadTags: threadTags, categoryTitle: categoryTitle, threadBody: threadBody, threadImage: threadImage, threadImageDescription: threadImageDescription, threadNSFW: threadNSFW, threadNSFL: threadNSFL, allowScreenShots: (allowScreenShots != undefined ? allowScreenShots : true)})}>
@@ -135,28 +134,24 @@ const SelectCategorySearchScreen = ({route, navigation}) => {
                 var itemsProcessed = 0;
                 allData.forEach(function (item, index) {
                     if (allData[index].imageKey !== "") {
-                        if (index+1 <= userLoadMax) {      
-                            async function asyncFunctionForImages() {
-                                const imageB64 = await getImageInCategory(allData[index].imageKey)
-                                var tempSectionsTemp = {data: [{categoryTitle: allData[index].categoryTitle, categoryDescription: allData[index].categoryDescription, members: allData[index].members, categoryTags: allData[index].categoryTags, image: imageB64, NSFW: allData[index].NSFW, NSFL: allData[index].NSFL, datePosted: allData[index].datePosted, allowScreenShots: allData[index].allowScreenShots}]}
-                                tempSections.push(tempSectionsTemp)
-                                itemsProcessed++;
-                                if(itemsProcessed === allData.length) {
-                                    setLoadingResults(false)
-                                    setChangeSections(tempSections)
-                                }
-                            }
-                            asyncFunctionForImages()
-                        }
-                    } else {
-                        if (index+1 <= userLoadMax) {      
-                            var tempSectionsTemp = {data: [{categoryTitle: allData[index].categoryTitle, categoryDescription: allData[index].categoryDescription, members: allData[index].members, categoryTags: allData[index].categoryTags, image: null, NSFW: allData[index].NSFW, NSFL: allData[index].NSFL, datePosted: allData[index].datePosted, allowScreenShots: allData[index].allowScreenShots}]}
+                        async function asyncFunctionForImages() {
+                            const imageB64 = await getImageInCategory(allData[index].imageKey)
+                            var tempSectionsTemp = {data: [{categoryTitle: allData[index].categoryTitle, categoryDescription: allData[index].categoryDescription, members: allData[index].members, categoryTags: allData[index].categoryTags, image: imageB64, NSFW: allData[index].NSFW, NSFL: allData[index].NSFL, datePosted: allData[index].datePosted, allowScreenShots: allData[index].allowScreenShots}]}
                             tempSections.push(tempSectionsTemp)
                             itemsProcessed++;
                             if(itemsProcessed === allData.length) {
                                 setLoadingResults(false)
                                 setChangeSections(tempSections)
                             }
+                        }
+                        asyncFunctionForImages()
+                    } else {
+                        var tempSectionsTemp = {data: [{categoryTitle: allData[index].categoryTitle, categoryDescription: allData[index].categoryDescription, members: allData[index].members, categoryTags: allData[index].categoryTags, image: null, NSFW: allData[index].NSFW, NSFL: allData[index].NSFL, datePosted: allData[index].datePosted, allowScreenShots: allData[index].allowScreenShots}]}
+                        tempSections.push(tempSectionsTemp)
+                        itemsProcessed++;
+                        if(itemsProcessed === allData.length) {
+                            setLoadingResults(false)
+                            setChangeSections(tempSections)
                         }
                     }
                 });


### PR DESCRIPTION
There was a hard limit of 10 in the frontend, so the frontend would receive the data but not display it if there were more than 10 categories to display. This hard limit was removed, and this pull request is a bandaid fix as the frontend shows all applicable categories with the user's search. This should be changed so it lazy loads a certain amount of categories at a time, and when the user scrolls the page it'll load more categories.