### PR TITLE
Stringify all error messages from backend before displaying them

### DIFF
--- a/App.js
+++ b/App.js
@@ -58,6 +58,7 @@ import {Logout} from './components/HandleLogout';
 import {storeJWT} from './jwtHandler';
 import mobileAds, { MaxAdContentRating, TestIds } from 'react-native-google-mobile-ads';
 import { SERVER_URL } from './defaults.js';
+import ParseErrorMessage from './components/ParseErrorMessage.js';
 
 mobileAds()
   .setRequestConfiguration({
@@ -197,7 +198,7 @@ const App = () => {
         console.log("No JWT passed?")
         //setAuthAsHeaders() // why not // cant do anymore since userid is used in the keys for multiple accounts
       } else if (status == 403) {
-        if (error.response.data.message == "Token generated.") {
+        if (ParseErrorMessage(error) == "Token generated.") {
           console.log("New token generated.")
           //refresh occured so repeat last request
           let token = error.response.data.token;
@@ -1338,7 +1339,7 @@ const App = () => {
               }).catch(error => {
                   console.error(error);
                   //setSubmitting(false);
-                  handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                  handleMessage(ParseErrorMessage(error));
               })
             }
             let credentialsListObject = await AsyncStorage.getItem('socialSquare_AllCredentialsList');

--- a/components/ParseErrorMessage.js
+++ b/components/ParseErrorMessage.js
@@ -1,0 +1,3 @@
+export default function ParseErrorMessage(error) {
+    return error?.response?.data?.message ? String(error?.response?.data?.message) : 'An unknown error occurred. Please check your network connection and try again.'
+}

--- a/components/Posts/ThreeDotMenuActionSheet.js
+++ b/components/Posts/ThreeDotMenuActionSheet.js
@@ -3,6 +3,7 @@ import ActionSheet from 'react-native-actionsheet';
 import axios from "axios";
 import { ServerUrlContext } from "../ServerUrlContext";
 import { useNavigation } from "@react-navigation/native";
+import ParseErrorMessage from "../ParseErrorMessage";
 
 const NotOwnerOptions = [
     'Report',
@@ -57,7 +58,7 @@ const ThreeDotMenuActionSheet = ({dispatch, threeDotsMenu}) => {
             }
         }).catch(error => {
             console.error(error)
-            alert(error?.response?.data?.message ? ('An error occured while deleting image post: ' + error?.response?.data?.message) : 'An error occured while deleting the image post. Please check your internet connection and then try again.')
+            alert('An error occurred while deleting image post:', ParseErrorMessage(error))
             dispatch({type: 'stopDeletePost', postIndex})
         })
     }
@@ -78,7 +79,7 @@ const ThreeDotMenuActionSheet = ({dispatch, threeDotsMenu}) => {
             }
         }).catch(error => {
             console.error(error)
-            alert(error?.response?.data?.message ? ('An error occured while deleting poll post: ' + error?.response?.data?.message) : 'An error occured while deleting the poll post. Please check your internet connection and then try again.')
+            alert('An error occurred while deleting poll post:', ParseErrorMessage(error))
             dispatch({type: 'stopDeletePost', postIndex})
         })
     }
@@ -99,7 +100,7 @@ const ThreeDotMenuActionSheet = ({dispatch, threeDotsMenu}) => {
             }
         }).catch(error => {
             console.error(error)
-            alert(error?.response?.data?.message ? ('An error occured while deleting thread post: ' + error?.response?.data?.message) : 'An error occured while deleting the thread post. Please check your internet connection and then try again.')
+            alert('An error occurred while deleting thread post:', ParseErrorMessage(error))
             dispatch({type: 'stopDeletePost', postIndex})
         })
     }

--- a/docs/TransferFromOtherPlatformsWebsites/TransferFromInstagram/App.js
+++ b/docs/TransferFromOtherPlatformsWebsites/TransferFromInstagram/App.js
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, View, TextInput, TouchableOpacity, ActivityIndicator, Image } from 'react-native';
 import React, {useEffect, useState} from 'react';
 import axios from 'axios';
+import ParseErrorMessage from '../../../components/ParseErrorMessage';
 
 //const postsJSON = require('./posts_1.json')
 
@@ -77,9 +78,9 @@ export default function App() {
           setCurrentAppPage('transfer')
         }
       }).catch((error) => {
-        console.log(error)
+        console.error(error)
         setLoggingIn(false)
-        setMessage(error?.response?.data?.message || String(error))
+        setMessage(ParseErrorMessage(error))
       })
     }
   }

--- a/hooks/useUpload.js
+++ b/hooks/useUpload.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const useUpload = (serverUrl, storedCredentials) => {
     const [posts, setPosts] = useState({})
@@ -109,7 +110,7 @@ const useUpload = (serverUrl, storedCredentials) => {
             }
 
         }).catch(error => {
-            handleError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection.', uploadId)
+            handleError(ParseErrorMessage(error), uploadId)
         })
     }
 
@@ -128,7 +129,7 @@ const useUpload = (serverUrl, storedCredentials) => {
             }
 
         }).catch(error => {
-            handleError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection.', uploadId)
+            handleError(ParseErrorMessage(error), uploadId)
         })
     }
 
@@ -150,7 +151,7 @@ const useUpload = (serverUrl, storedCredentials) => {
                 }
 
             }).catch(error => {
-                handleError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection.', uploadId)
+                handleError(ParseErrorMessage(error), uploadId)
             })
         } else if (selectFormat == "Images") {
             //Set up formdata
@@ -190,7 +191,7 @@ const useUpload = (serverUrl, storedCredentials) => {
                 }
 
             }).catch(error => {
-                handleError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection.', uploadId)
+                handleError(ParseErrorMessage(error), uploadId)
             })
         }
     }
@@ -229,7 +230,7 @@ const useUpload = (serverUrl, storedCredentials) => {
                 }
 
             }).catch(error => {
-                handleError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection.', uploadId)
+                handleError(ParseErrorMessage(error), uploadId)
             })
         } else {
             const url = serverUrl + '/tempRoute/postcategorywithoutimage';
@@ -246,7 +247,7 @@ const useUpload = (serverUrl, storedCredentials) => {
                 }
 
             }).catch(error => {
-                handleError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection.', uploadId)
+                handleError(ParseErrorMessage(error), uploadId)
             })
         }
     }

--- a/screens/ActivityScreens/PostUpvoteDownvoteActivity.js
+++ b/screens/ActivityScreens/PostUpvoteDownvoteActivity.js
@@ -22,6 +22,7 @@ import ThreadPost from '../../components/Posts/ThreadPost';
 import PollPost from '../../components/Posts/PollPost';
 import ThreeDotMenuActionSheet from '../../components/Posts/ThreeDotMenuActionSheet';
 import SocialSquareLogo_B64_png from '../../assets/SocialSquareLogo_Base64_png';
+import ParseErrorMessage from '../../components/ParseErrorMessage';
 
 const PostUpvoteDownvoteActivity = ({navigation, route}) => {
     const {storedCredentials, setStoredCredentials} = useContext(CredentialsContext);
@@ -104,7 +105,7 @@ const PostUpvoteDownvoteActivity = ({navigation, route}) => {
             }).catch(error => {
                 if (!(error instanceof CanceledError)) {
                     console.error(error)
-                    setErrorFetching(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection and try again.')
+                    setErrorFetching(ParseErrorMessage(error))
                     dispatch({type: 'stopLoad'})
                 }
             })

--- a/screens/CategoryHome.js
+++ b/screens/CategoryHome.js
@@ -49,6 +49,7 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useTheme } from '@react-navigation/native';
 
 import { ServerUrlContext } from '../components/ServerUrlContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const CategoryHome = ({navigation}) => {
     const {colors, dark} = useTheme()
@@ -136,7 +137,7 @@ const CategoryHome = ({navigation}) => {
         }).catch(error => {
             console.log(error);
             submitting = false;
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 

--- a/screens/CategoryViewPage.js
+++ b/screens/CategoryViewPage.js
@@ -87,6 +87,7 @@ import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
 import { getTimeFromUTCMS } from '../libraries/Time.js';
 import ThreadPost from '../components/Posts/ThreadPost';
 import usePostReducer from '../hooks/usePostReducer';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const CategoryViewPage = ({route, navigation}) => {
     const {colors, dark, indexNum} = useTheme()
@@ -224,7 +225,7 @@ const CategoryViewPage = ({route, navigation}) => {
         }).catch(error => {
             console.log(error);
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -263,7 +264,7 @@ const CategoryViewPage = ({route, navigation}) => {
                 }).catch(error => {
                     console.log(error);
                     setInCategory(beforeChange)
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED');
+                    handleMessage(ParseErrorMessage(error), 'FAILED');
                 })
             }
         } else {
@@ -378,7 +379,7 @@ const CategoryViewPage = ({route, navigation}) => {
 
         }).catch(error => {
             console.error(error);
-            dispatchThreads({type: 'error', error: error?.response?.data?.message || "An error occurred. Try checking your network connection and retry."})
+            dispatchThreads({type: 'error', error: ParseErrorMessage(error)})
         })
     }
 

--- a/screens/ChangeEmailPage.js
+++ b/screens/ChangeEmailPage.js
@@ -51,6 +51,7 @@ import { withRepeat } from 'react-native-reanimated';
 
 import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import { AllCredentialsStoredContext } from '../components/AllCredentialsStoredContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 
 const ChangeEmailPage = ({navigation}) => {
@@ -83,7 +84,7 @@ const ChangeEmailPage = ({navigation}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 

--- a/screens/ChangePasswordScreen.js
+++ b/screens/ChangePasswordScreen.js
@@ -24,6 +24,7 @@ import {Octicons, Ionicons, Fontisto} from '@expo/vector-icons';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
 import {storeJWT} from './../jwtHandler'
 import { CredentialsContext } from '../components/CredentialsContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const ChangePasswordScreen = ({navigation}) => {
     const {colors, dark} = useTheme();
@@ -57,7 +58,7 @@ const ChangePasswordScreen = ({navigation}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || 'An error occured. Try checking your network connection and then try again.');
+            handleMessage(ParseErrorMessage(error));
         })
     }
 

--- a/screens/CommentViewPage.js
+++ b/screens/CommentViewPage.js
@@ -94,6 +94,7 @@ import SocialSquareLogo_B64_png from '../assets/SocialSquareLogo_Base64_png';
 import { ProfilePictureURIContext } from '../components/ProfilePictureURIContext';
 
 import { ServerUrlContext } from '../components/ServerUrlContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const CommentViewPage = ({route, navigation}) => {
      //context
@@ -242,7 +243,7 @@ const CommentViewPage = ({route, navigation}) => {
         }).catch(error => {
             console.error(error);
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -382,7 +383,7 @@ const CommentViewPage = ({route, navigation}) => {
             console.log(error);
             setLoadingMoreComments(false)
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -411,7 +412,7 @@ const CommentViewPage = ({route, navigation}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -548,7 +549,7 @@ const CommentViewPage = ({route, navigation}) => {
                         neitherVotedComments.push(commentId)
                         setNeitherVotes(neitherVotedComments)
                     }
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', postNum);
+                    handleMessage(ParseErrorMessage(error), 'FAILED', postNum);
                 })
             }
         }
@@ -687,7 +688,7 @@ const CommentViewPage = ({route, navigation}) => {
                         neitherVotedComments.push(commentId)
                         setNeitherVotes(neitherVotedComments)
                     }
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', postNum);
+                    handleMessage(ParseErrorMessage(error), 'FAILED', postNum);
                 })
             }
         }

--- a/screens/EditProfile.js
+++ b/screens/EditProfile.js
@@ -27,6 +27,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import Octicons from 'react-native-vector-icons/Octicons';
 import { useIsFocused } from '@react-navigation/native';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const EditProfile = ({navigation, route}) => {
     const {colors, dark} = useTheme()
@@ -133,7 +134,7 @@ const EditProfile = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setChangingPfp(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -234,7 +235,7 @@ const EditProfile = ({navigation, route}) => {
                         }
                     }).catch(error => {
                         console.log(error);
-                        handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", "FAILED");
+                        handleMessage(ParseErrorMessage(error), "FAILED");
                         setSavingChanges(false);
                         setSavingChangesStatus(false);
                     })
@@ -272,7 +273,7 @@ const EditProfile = ({navigation, route}) => {
                     }
                 }).catch(error => {
                     console.log(error);
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", "FAILED");
+                    handleMessage(ParseErrorMessage(error), "FAILED");
                     setSavingChanges(false);
                     setSavingChangesStatus(false);
                 })
@@ -304,7 +305,7 @@ const EditProfile = ({navigation, route}) => {
                     }
                 }).catch(error => {
                     console.log(error);
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", "FAILED");
+                    handleMessage(ParseErrorMessage(error), "FAILED");
                     setSavingChanges(false);
                     setSavingChangesStatus(false);
                 })
@@ -346,8 +347,8 @@ const EditProfile = ({navigation, route}) => {
                 setIsPrivateAccount(true)
             }
         }).catch(error => {
-            console.log(error);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", "FAILED");
+            console.error(error);
+            handleMessage(ParseErrorMessage(error), "FAILED");
             setChangingPrivateAccount(false);
             setSavingChanges(false)
         })
@@ -378,8 +379,8 @@ const EditProfile = ({navigation, route}) => {
                 setIsPrivateAccount(false)
             }
         }).catch(error => {
-            console.log(error);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", "FAILED");
+            console.error(error);
+            handleMessage(ParseErrorMessage(error), "FAILED");
             setChangingPrivateAccount(false);
             setSavingChanges(false)
         })

--- a/screens/FindScreen.js
+++ b/screens/FindScreen.js
@@ -55,6 +55,7 @@ import { ExperimentalFeaturesEnabledContext } from '../components/ExperimentalFe
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
 import CategoryItem from '../components/Posts/CategoryItem.js';
 import useCategoryReducer from '../hooks/useCategoryReducer.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 class UserItem extends PureComponent {
     constructor(props) {
@@ -232,9 +233,8 @@ const FindScreen = ({navigation}) => {
                     console.warn('Cancelled intentionally')
                 } else {
                     console.error(error);
-                    console.log(error?.response?.data?.message)
                     setLoadingOne(false)
-                    setErrorOccured(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                    setErrorOccured(ParseErrorMessage(error));
                     setNoResults(false)
                 }
             })
@@ -316,7 +316,7 @@ const FindScreen = ({navigation}) => {
                         console.warn('Intentionally failed request')
                     } else {
                         console.error(error);
-                        dispatchCategories({type: 'error', error: error?.response?.data?.message ? String(error?.response?.data?.message) : 'An unknown error occurred. Please try checking your network connection and try again.'})
+                        dispatchCategories({type: 'error', error: ParseErrorMessage(error)})
                     }
                 })
             } else {

--- a/screens/ForgottenPasswordScreen.js
+++ b/screens/ForgottenPasswordScreen.js
@@ -23,6 +23,7 @@ import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import axios from 'axios';
 import { useIsFocused } from '@react-navigation/native';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const ForgottenPasswordScreen = ({navigation}) => {
     const {colors, dark} = useTheme();
@@ -56,7 +57,7 @@ const ForgottenPasswordScreen = ({navigation}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || 'An error occured. Try checking your network connection and then try again.');
+            handleMessage(ParseErrorMessage(error));
         })
     }
     return (

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -108,6 +108,7 @@ import ThreadPost from '../components/Posts/ThreadPost.js';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
 import ThreeDotMenuActionSheet from '../components/Posts/ThreeDotMenuActionSheet.js';
 import { BannerAd, BannerAdSize } from 'react-native-google-mobile-ads';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const {brand, primary, tertiary, greyish, darkLight, darkestBlue, slightlyLighterPrimary, slightlyLighterGrey, descTextColor, darkest, red, orange, yellow, green, purple} = Colors;
 
@@ -504,7 +505,7 @@ const HomeScreen = ({navigation, route}) => {
                 }).catch(error => {
                     console.log(error);
                     dispatchFollowingFeed({type: 'stopLoad'})
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                    handleMessage(ParseErrorMessage(error));
                 })
             }
         } else if ("For You") {
@@ -542,9 +543,8 @@ const HomeScreen = ({navigation, route}) => {
 
                 }).catch(error => {
                     console.error(error);
-                    console.error(error?.response?.data?.message || 'An unknown error occurred.')
                     dispatchForYouFeed({type: 'stopLoad'})
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                    handleMessage(ParseErrorMessage(error));
                 })
             }
         }
@@ -639,7 +639,7 @@ const HomeScreen = ({navigation, route}) => {
                 }).catch(error => {
                     console.log(error);
                     dispatchFollowingFeed({type: 'stopLoad'})
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                    handleMessage(ParseErrorMessage(error));
                 })
             } else if (currentFeed == "For You") {
                 dispatchForYouFeed({type: 'startReload'})
@@ -671,9 +671,8 @@ const HomeScreen = ({navigation, route}) => {
 
                 }).catch(error => {
                     console.error(error);
-                    console.error(error?.response?.data?.message || 'An unknown error occurred.')
                     dispatchForYouFeed({type: 'stopLoad'})
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                    handleMessage(ParseErrorMessage(error));
                 })
             }
         } else {
@@ -767,7 +766,7 @@ const HomeScreen = ({navigation, route}) => {
                             
                         }).catch(error => {
                             console.log(error);
-                            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', index);
+                            handleMessage(ParseErrorMessage(error), 'FAILED', index);
                             removeInCaseOfErrorOrNotSuccess(idOfPost)
                         })
                     }
@@ -802,7 +801,7 @@ const HomeScreen = ({navigation, route}) => {
                             
                         }).catch(error => {
                             console.log(error);
-                            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', index);
+                            handleMessage(ParseErrorMessage(error), 'FAILED', index);
                             removeInCaseOfErrorOrNotSuccess(idOfPost)
                         })
                     }
@@ -837,7 +836,7 @@ const HomeScreen = ({navigation, route}) => {
                             
                         }).catch(error => {
                             console.log(error);
-                            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', index);
+                            handleMessage(ParseErrorMessage(error), 'FAILED', index);
                             removeInCaseOfErrorOrNotSuccess(idOfPost)
                         })
                     }
@@ -986,7 +985,7 @@ const HomeScreen = ({navigation, route}) => {
                 }
             }).catch((error) => {
                 console.log(error);
-                alert(error?.response?.data?.message || 'An error occured. Try checking your internet connection and then try again.')
+                alert(ParseErrorMessage(error))
             });
         } else {
             logoPressedTimes.current = 0;

--- a/screens/HomeScreenSettings/Algorithm_HomeScreenSettings.js
+++ b/screens/HomeScreenSettings/Algorithm_HomeScreenSettings.js
@@ -30,6 +30,7 @@ import axios from 'axios';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import { StatusBarHeightContext } from '../../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../../components/ParseErrorMessage.js';
 
 var _ = require('lodash');
 
@@ -77,7 +78,7 @@ const Algorithm_HomeScreenSettings = ({navigation, route}) => {
             }
         }).catch(error => {
             setLoadingSettings(false);
-            setErrorOccuredWhileLoadingSettings(error?.response?.data?.message || ('An error occured: ' + String(error)));
+            setErrorOccuredWhileLoadingSettings(ParseErrorMessage(error));
         })
     }
 
@@ -135,7 +136,7 @@ const Algorithm_HomeScreenSettings = ({navigation, route}) => {
             } else {
                 Alert.alert(
                     'Error',
-                    error?.response?.data?.message || ('An error occured: ' + String(error)),
+                    ParseErrorMessage(error),
                     [
                         { text: 'OK', onPress: () => {}, style: 'cancel' },
                         {

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -60,6 +60,7 @@ import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import {storeJWT} from './../jwtHandler'
 
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const LoginScreen = ({navigation, route}) => {
     const { colors, dark } = useTheme();
@@ -101,7 +102,7 @@ const LoginScreen = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -169,13 +170,13 @@ const LoginScreen = ({navigation, route}) => {
                 //setSubmitting(false);
     
             }).catch(error => {
-                if (error?.response?.data?.message === 'No profile image.') {
+                if (ParseErrorMessage(error) === 'No profile image.') {
                     console.log('This account does not have a profile picture')
                     setProfilePictureUri(SocialSquareLogo_B64_png)
                     setProfilePictureData([SocialSquareLogo_B64_png, message, status, credentialsToUse])
                 } else {
                     console.error(error);
-                    handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                    handleMessage(ParseErrorMessage(error));
                     setDownloadingPfp(false)
                 }
             })

--- a/screens/NotificationsSettingsScreen.js
+++ b/screens/NotificationsSettingsScreen.js
@@ -36,6 +36,7 @@ import axios from 'axios';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 var _ = require('lodash');
 
@@ -83,7 +84,7 @@ const NotificationsSettingsScreen = ({navigation}) => {
                 setShowSettings(true)
             }
         }).catch(error => {
-            setErrorOccuredDownloadingNotificationSettings(error?.response?.data?.message || ('An error occured: ' + String(error)))
+            setErrorOccuredDownloadingNotificationSettings(ParseErrorMessage(error))
         })
     }
 
@@ -102,7 +103,7 @@ const NotificationsSettingsScreen = ({navigation}) => {
                 navigation.goBack()
             }
         }).catch(error => {
-            alert(error?.response?.data?.message || ('An error occured: ' + String(error)))
+            alert(ParseErrorMessage(error))
             setSavingChanges(false)
         })
     }

--- a/screens/PrivacySettings.js
+++ b/screens/PrivacySettings.js
@@ -14,6 +14,7 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import axios from 'axios';
 import { CredentialsContext } from '../components/CredentialsContext';
 import RadioButton from '../components/RadioButton';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 var _ = require('lodash');
 
@@ -50,7 +51,7 @@ const PrivacySettings = ({navigation}) => {
             }
         }).catch(error => {
             setLoading(false)
-            setError(error?.response?.data?.message || 'An error occured. Check your network connection and try again.')
+            setError(ParseErrorMessage(error))
             console.error(error)
         })
     }
@@ -94,7 +95,7 @@ const PrivacySettings = ({navigation}) => {
         }).catch(error => {
             console.error(error)
             setSavingChanges(false)
-            alert(error?.response?.data?.message || 'An error occured while saving privacy settings. Please try again later.')
+            alert(ParseErrorMessage(error))
         })
     }
 

--- a/screens/ProfilePages.js
+++ b/screens/ProfilePages.js
@@ -118,6 +118,7 @@ import ThreadPost from '../components/Posts/ThreadPost';
 import ThreeDotMenuActionSheet from '../components/Posts/ThreeDotMenuActionSheet';
 import useCategoryReducer from '../hooks/useCategoryReducer';
 import CategoryItem from '../components/Posts/CategoryItem';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const ProfilePages = ({ route, navigation }) => {
     const [images, dispatchImages] = usePostReducer();
@@ -225,8 +226,7 @@ const ProfilePages = ({ route, navigation }) => {
             }).catch(error => {
                 console.error(error);
                 //setSubmitting(false);
-                console.error(error?.response?.data?.message || 'An unknown error occurred.')
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                handleMessage(ParseErrorMessage(error));
                 setLoadingFollowers('Error')
                 resolve()
             })
@@ -628,7 +628,7 @@ const ProfilePages = ({ route, navigation }) => {
                 layoutImagePosts({data});
             }).catch(error => {
                 console.error(error);
-                dispatchImages({type: 'error', error: error?.response?.data?.message || 'An unknown error occurred while loading images. Please check your internet connection and retry.'})
+                dispatchImages({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -786,7 +786,7 @@ const ProfilePages = ({ route, navigation }) => {
                 layoutPollPosts(data);
             }).catch(error => {
                 console.error(error);
-                dispatchPolls({type: 'error', error: error?.response?.data?.message || 'An unknown error occurred while loading polls. Please check your internet connection and retry.'})
+                dispatchPolls({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -871,7 +871,7 @@ const ProfilePages = ({ route, navigation }) => {
             }
         }).catch(error => {
             console.error('An error occurred while loading threads from ProfilePages.js:', error)
-            dispatchThreads({type: 'error', error: error?.response?.data?.message || 'An unknown error occurred while loading threads. Please check your internet connection and try again.'})
+            dispatchThreads({type: 'error', error: ParseErrorMessage(error)})
         })
     }
 
@@ -901,7 +901,7 @@ const ProfilePages = ({ route, navigation }) => {
                 layoutThreadPosts({data});
             }).catch(error => {
                 console.error(error);
-                dispatchThreads({type: 'error', error: error?.response?.data?.message || "An error occured. Try checking your network connection and retry."})
+                dispatchThreads({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -989,7 +989,7 @@ const ProfilePages = ({ route, navigation }) => {
                 layoutCategoriesFound(data)
             }).catch(error => {
                 console.error(error);
-                dispatchCategories({type: 'error', error: error?.response?.data?.message || "An error occured. Try checking your network connection and retry."})
+                dispatchCategories({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -1098,7 +1098,7 @@ const ProfilePages = ({ route, navigation }) => {
                     }).catch(error => {
                         console.error(error);
                         setSettingUpChat(false);
-                        setSettingUpChatErrorMessage(error?.response?.data?.message || "Network Error.");
+                        setSettingUpChatErrorMessage(ParseErrorMessage(error));
                         setSettingUpChatErrorOrigin('creating the DM')
                     })
                 }
@@ -1131,7 +1131,7 @@ const ProfilePages = ({ route, navigation }) => {
         }).catch(error => {
             console.log(error);
             setSettingUpChat(false)
-            setSettingUpChatErrorMessage(error?.response?.data?.message || "Network Error.");
+            setSettingUpChatErrorMessage(ParseErrorMessage(error));
             setSettingUpChatErrorOrigin('getting the chat info from ID')
         })
     }
@@ -1168,7 +1168,7 @@ const ProfilePages = ({ route, navigation }) => {
                 }
             }).catch(error => {
                 console.error(error)
-                alert(error?.response?.data?.message || 'An error occured. Please try again.')
+                alert(ParseErrorMessage(error))
                 setBlockingUser(false)
             })
         } else {
@@ -1288,7 +1288,7 @@ const ProfilePages = ({ route, navigation }) => {
             }).catch(error => {
                 console.log(error);
                 setTogglingFollow(false)
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                handleMessage(ParseErrorMessage(error));
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true})

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -111,6 +111,7 @@ import ThreadPost from '../components/Posts/ThreadPost.js';
 import ThreeDotMenuActionSheet from '../components/Posts/ThreeDotMenuActionSheet.js';
 import useCategoryReducer from '../hooks/useCategoryReducer.js';
 import CategoryItem from '../components/Posts/CategoryItem.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const Welcome = ({navigation, route}) => {
     const [images, dispatchImages] = usePostReducer();
@@ -503,7 +504,7 @@ const Welcome = ({navigation, route}) => {
                 layoutImagePosts({data});
             }).catch(error => {
                 console.error(error);
-                dispatchImages({type: 'error', error: error?.response?.data?.message || 'An unknown error occurred while loading images. Please check your internet connection and retry.'})
+                dispatchImages({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -661,7 +662,7 @@ const Welcome = ({navigation, route}) => {
                 layoutPollPosts(data);
             }).catch(error => {
                 console.error(error);
-                dispatchPolls({type: 'error', error: error?.response?.data?.message || 'An unknown error occurred while loading polls. Please check your internet connection and retry.'})
+                dispatchPolls({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -745,7 +746,7 @@ const Welcome = ({navigation, route}) => {
             }
         }).catch(error => {
             console.error('An error occurred while loading threads from ProfileScreen.js:', error)
-            dispatchThreads({type: 'error', error: error?.response?.data?.message || 'An unknown error occurred while loading threads. Please check your internet connection and try again.'})
+            dispatchThreads({type: 'error', error: ParseErrorMessage(error)})
         })
     }
 
@@ -775,7 +776,7 @@ const Welcome = ({navigation, route}) => {
                 layoutThreadPosts({data});
             }).catch(error => {
                 console.error(error);
-                dispatchThreads({type: 'error', error: error?.response?.data?.message || "An error occured. Try checking your network connection and retry."})
+                dispatchThreads({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -863,7 +864,7 @@ const Welcome = ({navigation, route}) => {
                 layoutCategoriesFound(data)
             }).catch(error => {
                 console.error(error);
-                dispatchCategories({type: 'error', error: error?.response?.data?.message || "An error occured. Try checking your network connection and retry."})
+                dispatchCategories({type: 'error', error: ParseErrorMessage(error)})
             })
         }
     }
@@ -975,7 +976,7 @@ const Welcome = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setChangingPfp(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -1095,7 +1096,7 @@ const Welcome = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setRefreshing(false)
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     })
 

--- a/screens/ProfileStats.js
+++ b/screens/ProfileStats.js
@@ -22,6 +22,7 @@ import { AllCredentialsStoredContext } from '../components/AllCredentialsStoredC
 import useSharedCode from '../hooks/useSharedCode'
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 let arrayOfUserChanges = [];
 let userIDToUnfollow = undefined;
@@ -107,7 +108,7 @@ const ProfileStats = ({navigation, route}) => {
                     })
                 }
             }).catch(error => {
-                setError(error?.response?.data?.message || 'An error occured.')
+                setError(ParseErrorMessage(error))
                 setLoading(false)
                 console.error(error)
             })

--- a/screens/ReportAccount.js
+++ b/screens/ReportAccount.js
@@ -13,6 +13,7 @@ import { CredentialsContext } from '../components/CredentialsContext';
 import { useTheme } from '@react-navigation/native';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
 import { ServerUrlContext } from '../components/ServerUrlContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const ReportAccount = ({navigation, route: routeData}) => {
     const { colors } = useTheme();
@@ -50,7 +51,7 @@ const ReportAccount = ({navigation, route: routeData}) => {
                 console.log("An error occured while reporting user.")
                 console.log(error)
                 setSendingReport(false)
-                setError(error?.response?.data?.message || 'An error occured. Please check your internet connection and try again later.')
+                setError(ParseErrorMessage(error))
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true})

--- a/screens/ReportPost.js
+++ b/screens/ReportPost.js
@@ -18,6 +18,7 @@ import { Formik } from 'formik';
 import {Octicons} from '@expo/vector-icons';
 import axios from 'axios';
 import { ServerUrlContext } from '../components/ServerUrlContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 
 const ReportPost = ({navigation, route}) => {
@@ -65,7 +66,7 @@ const ReportPost = ({navigation, route}) => {
             }
         }).catch(error => {
             console.error(error)
-            setError(error?.response?.data?.message || 'An error occured while sending report. Please check your internet connection and try again later.')
+            setError(ParseErrorMessage(error))
         })
     }
 

--- a/screens/ResetPasswordAfterVerificationScreen.js
+++ b/screens/ResetPasswordAfterVerificationScreen.js
@@ -23,6 +23,7 @@ import { Formik } from 'formik';
 import {Octicons, Ionicons, Fontisto} from '@expo/vector-icons';
 import { useIsFocused } from '@react-navigation/native';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const ResetPasswordAfterVerificationScreen = ({navigation, route}) => {
     const {colors, dark} = useTheme();
@@ -56,7 +57,7 @@ const ResetPasswordAfterVerificationScreen = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || 'An error occured. Try checking your network connection and then try again.');
+            handleMessage(ParseErrorMessage(error));
         })
     }
 

--- a/screens/ResetPasswordScreen.js
+++ b/screens/ResetPasswordScreen.js
@@ -24,6 +24,7 @@ import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import axios from 'axios';
 import { useIsFocused } from '@react-navigation/native';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const ResetPasswordScreen = ({route, navigation}) => {
     const {colors, dark} = useTheme();
@@ -104,7 +105,7 @@ const ResetPasswordScreen = ({route, navigation}) => {
             setSubmitting(false);
         }).catch((error) => {
             console.error(error)
-            handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+            handleMessage(ParseErrorMessage(error), 'FAILED');
             setSubmitting(false);
             setContainerIsFocused(true);
             inputFocusRef?.current?.focus();
@@ -138,7 +139,7 @@ const ResetPasswordScreen = ({route, navigation}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || 'An error occured while resending verification code. Try checking your network connection and then try again.');
+            handleMessage(ParseErrorMessage(error));
         });
     }
     return (

--- a/screens/SafetySettings/BlockedAccountsScreen.js
+++ b/screens/SafetySettings/BlockedAccountsScreen.js
@@ -37,6 +37,7 @@ import axios from 'axios';
 import AntDesign from 'react-native-vector-icons/AntDesign';
 import Ionicons from 'react-native-vector-icons/Ionicons.js';
 import { StatusBarHeightContext } from '../../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../../components/ParseErrorMessage.js';
 
 
 const BlockedAccountsScreen = ({navigation}) => {
@@ -61,7 +62,7 @@ const BlockedAccountsScreen = ({navigation}) => {
             setBlockedAccounts(data);
         }).catch(error => {
             console.error(error);
-            setErrorOccurred(error?.response?.data?.message || String(error))
+            setErrorOccurred(ParseErrorMessage(error))
         })
     }
 

--- a/screens/SecuritySettingsScreens/LoginActivity.js
+++ b/screens/SecuritySettingsScreens/LoginActivity.js
@@ -15,6 +15,7 @@ import { StatusBarHeightContext } from '../../components/StatusBarHeightContext.
 import axios from 'axios';
 import { ServerUrlContext } from '../../components/ServerUrlContext.js';
 import { getTimeFromUTCMS } from '../../libraries/Time.js';
+import ParseErrorMessage from '../../components/ParseErrorMessage.js';
 
 class RefreshTokenItem extends Component {
     constructor(props) {
@@ -82,7 +83,7 @@ const LoginActivity = ({navigation}) => {
                 })
             }
         }).catch(error => {
-            alert(error?.response?.data?.message || 'An unknown error occurred while logging out device. Please try again later.')
+            alert(ParseErrorMessage(error))
         })
     }
 
@@ -104,7 +105,7 @@ const LoginActivity = ({navigation}) => {
                 setLoading(false)
             }).catch(error => {
                 console.error(error)
-                setError(error?.response?.data?.message || "An unknown error occurred. Please try again.")
+                setError(ParseErrorMessage(error))
                 setLoading(false)
             })
         }
@@ -135,7 +136,7 @@ const LoginActivity = ({navigation}) => {
             }
         }).catch(error => {
             console.error(error)
-            alert(error?.response?.data?.message || 'An unknown error occurred. Please try again.')
+            alert(ParseErrorMessage(error))
         })
     }
 

--- a/screens/SecuritySettingsScreens/LoginActivitySettings.js
+++ b/screens/SecuritySettingsScreens/LoginActivitySettings.js
@@ -13,6 +13,7 @@ import { StatusBarHeightContext } from '../../components/StatusBarHeightContext.
 import axios from 'axios';
 import { ServerUrlContext } from '../../components/ServerUrlContext.js';
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import ParseErrorMessage from '../../components/ParseErrorMessage.js';
 
 var _ = require('lodash');
 
@@ -49,7 +50,7 @@ const LoginActivitySettings = ({navigation, route}) => {
         }).catch(error => {
             setSettingsLoading(false)
             console.error(error)
-            setSettingsLoadError(error?.response?.data?.message || 'An unknown error occurred. Please check your internet connection and try again.')
+            setSettingsLoadError(ParseErrorMessage(error))
         })
     }
 
@@ -108,7 +109,7 @@ const LoginActivitySettings = ({navigation, route}) => {
                 }).catch(error => {
                     setSavingSettings(false)
                     console.error(error)
-                    showAccountSetupAlert(error?.response?.data?.message)
+                    showAccountSetupAlert(ParseErrorMessage(error))
                 })
             } else {
                 goToNextScreen()
@@ -132,7 +133,7 @@ const LoginActivitySettings = ({navigation, route}) => {
             }).catch(error => {
                 console.error(error)
                 setSavingSettings(false)
-                alert(error?.response?.data?.message || 'An unknown error occurred while saving login activity settings. Please check your internet connection and try again.')
+                alert(ParseErrorMessage(error))
             })
         }
     }

--- a/screens/SecuritySettingsScreens/MFAScreens/ActivateEmailMFA.js
+++ b/screens/SecuritySettingsScreens/MFAScreens/ActivateEmailMFA.js
@@ -14,6 +14,7 @@ import {
 import axios from 'axios';
 import {ServerUrlContext} from '../../../components/ServerUrlContext.js';
 import { StatusBarHeightContext } from '../../../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../../../components/ParseErrorMessage.js';
 
 const ActivateEmailMFA = ({navigation, route}) => {
     const {colors, dark} = useTheme();
@@ -42,7 +43,7 @@ const ActivateEmailMFA = ({navigation, route}) => {
         }).catch(error => {
             console.error(error);
             setTurningOffEmailMFA(false);
-            alert(error?.response?.data?.message || "An error occured while turning off email multi-factor authentication. Please try again later.");
+            alert(ParseErrorMessage(error));
         })
     }
     return (

--- a/screens/SelectCategorySearchScreen.js
+++ b/screens/SelectCategorySearchScreen.js
@@ -26,6 +26,7 @@ import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import SocialSquareLogo_B64_png from '../assets/SocialSquareLogo_Base64_png.js';
 import CategoryItem from '../components/Posts/CategoryItem.js';
 import useCategoryReducer from '../hooks/useCategoryReducer.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const SelectCategorySearchScreen = ({route, navigation}) => {
     const {colors, dark} = useTheme()
@@ -113,7 +114,7 @@ const SelectCategorySearchScreen = ({route, navigation}) => {
             }).catch(error => {
                 if (!(error instanceof CanceledError)) {
                     console.error(error);
-                    dispatch({type: 'error', error: error?.response?.data?.message ? String(error?.response?.data?.message) : 'An unknown error occurred. Please try checking your network connection and try again.'})
+                    dispatch({type: 'error', error: ParseErrorMessage(error)})
                 }
             })
         }

--- a/screens/Signup.js
+++ b/screens/Signup.js
@@ -59,6 +59,7 @@ import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import {storeJWT} from './../jwtHandler'
 
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 
 const Signup = ({navigation, route}) => {
@@ -111,7 +112,7 @@ const Signup = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -207,7 +208,7 @@ const Signup = ({navigation, route}) => {
             }).catch(error => {
                 console.log(error);
                 setUsernameIsAvailable(false);
-                setUsernameAvailableMessage(error?.response?.data?.message || 'An error occured. Try checking your network connection and retry.')
+                setUsernameAvailableMessage(ParseErrorMessage(error))
                 setUsernameAvailableMessageColor(colors.red)
             })
         }

--- a/screens/ThreadViewPage.js
+++ b/screens/ThreadViewPage.js
@@ -98,6 +98,7 @@ import SocialSquareLogo_B64_png from '../assets/SocialSquareLogo_Base64_png';
 
 import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const ThreadViewPage = ({navigation, route}) => {
     const {colors, dark} = useTheme()
@@ -278,7 +279,7 @@ const ThreadViewPage = ({navigation, route}) => {
         }).catch(error => {
             console.error(error);
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -413,7 +414,7 @@ const ThreadViewPage = ({navigation, route}) => {
             console.error(error);
             setLoadingMoreComments(false)
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -442,7 +443,7 @@ const ThreadViewPage = ({navigation, route}) => {
         }).catch(error => {
             console.error(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -580,7 +581,7 @@ const ThreadViewPage = ({navigation, route}) => {
                             neitherVotedComments.push(commentId)
                             setNeitherVotes(neitherVotedComments)
                         }
-                        handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', postNum);
+                        handleMessage(ParseErrorMessage(error), 'FAILED', postNum);
                     })
                 }
             }
@@ -723,7 +724,7 @@ const ThreadViewPage = ({navigation, route}) => {
                             neitherVotedComments.push(commentId)
                             setNeitherVotes(neitherVotedComments)
                         }
-                        handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', postNum);
+                        handleMessage(ParseErrorMessage(error), 'FAILED', postNum);
                     })
                 }
             }
@@ -874,7 +875,7 @@ const ThreadViewPage = ({navigation, route}) => {
             }).catch(error => {
                 console.error(error);
                 setThreadUpOrDownVoted("UpVoted");
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true});
@@ -916,7 +917,7 @@ const ThreadViewPage = ({navigation, route}) => {
             }).catch(error => {
                 console.error(error);
                 setThreadUpOrDownVoted("UpVoted")
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true});

--- a/screens/VerifyEmailCodeScreen.js
+++ b/screens/VerifyEmailCodeScreen.js
@@ -32,6 +32,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import {storeJWT} from './../jwtHandler'
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext.js';
+import ParseErrorMessage from '../components/ParseErrorMessage.js';
 
 const VerifyEmailCodeScreen = ({route, navigation}) => {
     const {colors, dark} = useTheme();
@@ -150,7 +151,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
             }).catch(error => {
                 console.error(error);
                 //setSubmitting(false);
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                handleMessage(ParseErrorMessage(error));
             })
         }
         NetInfo.fetch().then(state => {
@@ -246,7 +247,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
                 setSubmitting(false);
             }).catch((error) => {
                 console.error(error)
-                handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
                 setSubmitting(false);
                 setContainerIsFocused(true);
                 inputFocusRef?.current?.focus();
@@ -273,7 +274,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
                 }
             }).catch((error) => {
                 console.error(error)
-                handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
                 setSubmitting(false);
                 setContainerIsFocused(true);
                 inputFocusRef?.current?.focus();
@@ -300,7 +301,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
                 }
             }).catch((error) => {
                 console.error(error)
-                handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
                 setSubmitting(false);
                 setContainerIsFocused(true);
                 inputFocusRef?.current?.focus();
@@ -328,7 +329,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
                 setSubmitting(false);
             }).catch((error) => {
                 console.error(error)
-                handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
                 setSubmitting(false);
                 setContainerIsFocused(true);
                 inputFocusRef?.current?.focus();
@@ -353,7 +354,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
                 }
             }).catch((error) => {
                 console.error(error)
-                handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
                 setSubmitting(false);
                 setContainerIsFocused(true);
                 inputFocusRef?.current?.focus();
@@ -378,7 +379,7 @@ const VerifyEmailCodeScreen = ({route, navigation}) => {
                 }
             }).catch((error) => {
                 console.error(error)
-                handleMessage(error?.response?.data?.message || error?.message || 'An unexpected error occured. Try again.', 'FAILED');
+                handleMessage(ParseErrorMessage(error), 'FAILED');
                 setSubmitting(false);
                 setContainerIsFocused(true);
                 inputFocusRef?.current?.focus();

--- a/screens/VerifyEmailScreen.js
+++ b/screens/VerifyEmailScreen.js
@@ -21,6 +21,7 @@ import {
 import Octicons from 'react-native-vector-icons/Octicons';
 import { CredentialsContext } from '../components/CredentialsContext';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 const VerifyEmailScreen = ({navigation, route}) => {
     const [message, setMessage] = useState();
@@ -68,7 +69,7 @@ const VerifyEmailScreen = ({navigation, route}) => {
         }).catch(error => {
             console.log(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || 'An error occured. Try checking your network connection and then try again.');
+            handleMessage(ParseErrorMessage(error));
         })
     }
 

--- a/screens/ViewImagePostPage.js
+++ b/screens/ViewImagePostPage.js
@@ -113,6 +113,7 @@ import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
 import usePostReducer from '../hooks/usePostReducer';
 import ImagePost from '../components/Posts/ImagePost';
 import ThreeDotMenuActionSheet from '../components/Posts/ThreeDotMenuActionSheet';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 
 const ViewImagePostPage = ({route, navigation}) => {
@@ -287,7 +288,7 @@ const ViewImagePostPage = ({route, navigation}) => {
             console.error(error);
             setLoadingMoreComments(false)
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -316,7 +317,7 @@ const ViewImagePostPage = ({route, navigation}) => {
         }).catch(error => {
             console.error(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 

--- a/screens/ViewPollPostPage.js
+++ b/screens/ViewPollPostPage.js
@@ -105,6 +105,7 @@ import { ProfilePictureURIContext } from '../components/ProfilePictureURIContext
 
 import { ServerUrlContext } from '../components/ServerUrlContext.js';
 import { StatusBarHeightContext } from '../components/StatusBarHeightContext';
+import ParseErrorMessage from '../components/ParseErrorMessage';
 
 
 const ViewPollPostPage = ({route, navigation}) => {
@@ -305,7 +306,7 @@ const ViewPollPostPage = ({route, navigation}) => {
         }).catch(error => {
             console.error(error);
             //setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -436,7 +437,7 @@ const ViewPollPostPage = ({route, navigation}) => {
             console.error(error);
             //setSubmitting(false);
             setLoadingMoreComments(false)
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -465,7 +466,7 @@ const ViewPollPostPage = ({route, navigation}) => {
         }).catch(error => {
             console.error(error);
             setSubmitting(false);
-            handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+            handleMessage(ParseErrorMessage(error));
         })
     }
 
@@ -843,7 +844,7 @@ const ViewPollPostPage = ({route, navigation}) => {
             }).catch(error => {
                 console.error(error);
                 setSubmitting(false);
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.");
+                handleMessage(ParseErrorMessage(error));
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true})
@@ -888,7 +889,7 @@ const ViewPollPostPage = ({route, navigation}) => {
             }).catch(error => {
                 console.error(error);
                 setPollUpOrDownVoted(beforeChange)
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', postNum);
+                handleMessage(ParseErrorMessage(error), 'FAILED', postNum);
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true})
@@ -928,7 +929,7 @@ const ViewPollPostPage = ({route, navigation}) => {
             }).catch(error => {
                 console.error(error);
                 setPollUpOrDownVoted(beforeChange)
-                handleMessage(error?.response?.data?.message || "An error occured. Try checking your network connection and retry.", 'FAILED', postNum);
+                handleMessage(ParseErrorMessage(error), 'FAILED', postNum);
             })
         } else {
             navigation.navigate('ModalLoginScreen', {modal: true})


### PR DESCRIPTION
The backend is supposed to send a stringified error message, but a few days ago it was discovered that there was a bug in error handling for Temp.js, User.js, and Admin.js API routes that would send an error object instead of a string, and if an error occurred in the backend then the backend would send an object to the client and the frontend would crash.

Ideally the backend should send a string, but this pull request adds an extra layer of defence to prevent the app from crashing just in case the backend doesn't send a string.