### PR TITLE
Fixed SocialSquare crashing on certain screens if the user gets logged out

### DIFF
--- a/App.js
+++ b/App.js
@@ -1291,7 +1291,7 @@ const App = () => {
           if (result !== null) {
             setStoredCredentials(JSON.parse(result));
           } else {
-            setStoredCredentials(null);
+            setStoredCredentials({});
           }
           async function refreshProfilePictureContext(credentials) {
             const getProfilePicture = () => {
@@ -1344,8 +1344,8 @@ const App = () => {
             }
             let credentialsListObject = await AsyncStorage.getItem('socialSquare_AllCredentialsList');
             if (credentialsListObject == null && credentials) {
-              setStoredCredentials(null);
-              setAllCredentialsStoredList(null);
+              setStoredCredentials({});
+              setAllCredentialsStoredList([]);
             } else {
               let parsedCredentialsListObject = JSON.parse(credentialsListObject);
               setAllCredentialsStoredList(parsedCredentialsListObject);

--- a/components/HandleLogout.js
+++ b/components/HandleLogout.js
@@ -15,10 +15,10 @@ export function Logout(storedCredentials, setStoredCredentials, allCredentialsSt
             console.log('Running logout code for when allCredentialsStoredLists length is 1 or 0');
             setProfilePictureUri(SocialSquareLogo_B64_png);
             AsyncStorage.removeItem('socialSquareCredentials').then(() => {
-                setStoredCredentials(null)
+                setStoredCredentials({})
             })
             AsyncStorage.removeItem('socialSquare_AllCredentialsList').then(() => {
-                setAllCredentialsStoredList(null)
+                setAllCredentialsStoredList({})
             })
             Promise.all([
                 SecureStore.deleteItemAsync(storedCredentials._id + '-auth-web-token'),
@@ -59,10 +59,10 @@ export function Logout(storedCredentials, setStoredCredentials, allCredentialsSt
     } else {
         setProfilePictureUri(SocialSquareLogo_B64_png);
         AsyncStorage.removeItem('socialSquareCredentials').then(() => {
-            setStoredCredentials(null)
+            setStoredCredentials({})
         })
         AsyncStorage.removeItem('socialSquare_AllCredentialsList').then(() => {
-            setAllCredentialsStoredList(null)
+            setAllCredentialsStoredList([])
         })
         Promise.all([
             SecureStore.deleteItemAsync(storedCredentials._id + '-auth-web-token'),
@@ -81,8 +81,8 @@ export function Logout(storedCredentials, setStoredCredentials, allCredentialsSt
 
 export async function LogoutOfAllAccounts(allCredentialsStoredList, setStoredCredentials, setAllCredentialsStoredList, navigation, setProfilePictureUri) {
     deleteHeaders()
-    setStoredCredentials(null)
-    setAllCredentialsStoredList(null)
+    setStoredCredentials({})
+    setAllCredentialsStoredList([])
     setProfilePictureUri(SocialSquareLogo_B64_png);
     await AsyncStorage.removeItem('socialSquareCredentials')
     await AsyncStorage.removeItem('socialSquare_AllCredentialsList')

--- a/screens/SecuritySettingsScreen.js
+++ b/screens/SecuritySettingsScreen.js
@@ -144,7 +144,7 @@ const SecuritySettingsScreen = ({navigation}) => {
 
     useEffect(() => {
         if (destroyingLocalData == true && prevDestroyingLocalData == false) {
-            setStoredCredentials(null)
+            setStoredCredentials({})
             setAppStylingContextState('Default')
             setProfilePictureUri(SocialSquareLogo_B64_png);
             setDestroyingLocalData(false)


### PR DESCRIPTION
This was solved by setting storedCredentials to an empty object and setting allCredentialsStoredList to an empty array when logging out.