### PR TITLE
Fixed app not sending notification key on login

### DIFF
--- a/components/HandleLogout.js
+++ b/components/HandleLogout.js
@@ -104,6 +104,9 @@ export async function LogoutOfAllAccounts(allCredentialsStoredList, setStoredCre
             }),
             ...allCredentialsStoredList.map(credentials => {
                 return SecureStore.deleteItemAsync(credentials._id + '-auth-refresh-token-id')
+            }),
+            ...allCredentialsStoredList.map(credentials => {
+                return AsyncStorage.removeItem(`deviceNotificationKey-${credentials._id}`)
             })
         ]
 

--- a/components/HandleLogout.js
+++ b/components/HandleLogout.js
@@ -23,7 +23,8 @@ export function Logout(storedCredentials, setStoredCredentials, allCredentialsSt
             Promise.all([
                 SecureStore.deleteItemAsync(storedCredentials._id + '-auth-web-token'),
                 SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token'),
-                SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token-id')
+                SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token-id'),
+                AsyncStorage.removeItem(`deviceNotificationKey-${storedCredentials._id}`)
             ]).then(() => {
                 navigation.reset({
                     index: 0,
@@ -47,7 +48,8 @@ export function Logout(storedCredentials, setStoredCredentials, allCredentialsSt
             Promise.all([
                 SecureStore.deleteItemAsync(storedCredentials._id + '-auth-web-token'),
                 SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token'),
-                SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token-id')
+                SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token-id'),
+                AsyncStorage.removeItem(`deviceNotificationKey-${storedCredentials._id}`)
             ]).then(() => {
                 navigation.reset({
                     index: 0,
@@ -69,7 +71,8 @@ export function Logout(storedCredentials, setStoredCredentials, allCredentialsSt
         Promise.all([
             SecureStore.deleteItemAsync(storedCredentials._id + '-auth-web-token'),
             SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token'),
-            SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token-id')
+            SecureStore.deleteItemAsync(storedCredentials._id + '-auth-refresh-token-id'),
+            AsyncStorage.removeItem(`deviceNotificationKey-${storedCredentials._id}`)
         ]).then(() => {
             navigation.reset({
                 index: 0,


### PR DESCRIPTION
The old temp/sendnotificationkey API would store the notification key in the User document and the key would permanently stay there. The updated temp/sendnotificationkey API now stores the notification key in a RefreshToken document so when a device gets logged out, that device no longer gets any notifications from the account. Previously, SocialSquare would not resend the notification key after getting logged back in as the app already had it saved in AsyncStorage so it assumed it did not have to re-uplaod the key. Now whenever the user gets logged out, the notification key is deleted from AsyncStorage and the key is re-uploaded to the server on the next account login.